### PR TITLE
Implement message passing (QueueDataStore)

### DIFF
--- a/pyredis/commands/commands.py
+++ b/pyredis/commands/commands.py
@@ -60,7 +60,7 @@ def set_command(input, datastore):
 
         key = input.data[1].data
         value = input.data[2].data
-        datastore[key] = value
+        datastore.set(key, value)
         return SimpleString("OK").serialize()
     except Exception as e:
         return Error(e).serialize()
@@ -72,7 +72,7 @@ def get_command(input, datastore):
             return Error("ERR wrong number of arguments for 'get' command").serialize()
 
         key = input.data[1].data
-        value = datastore[key]
+        value = datastore.get(key)
         return BulkString(value).serialize()
     except Exception:
         return Nil().serialize()

--- a/pyredis/datastore/__init__.py
+++ b/pyredis/datastore/__init__.py
@@ -1,0 +1,2 @@
+from .lock_datastore import *
+from .queue_datastore import *

--- a/pyredis/datastore/lock_datastore.py
+++ b/pyredis/datastore/lock_datastore.py
@@ -13,3 +13,11 @@ class LockDataStore:
     def __setitem__(self, key, value):
         with self._lock:
             self._data[key] = value
+
+    def get(self, key):
+        with self._lock:
+            return self._data[key]
+
+    def set(self, key, value):
+        with self._lock:
+            self._data[key] = value

--- a/pyredis/datastore/lock_datastore.py
+++ b/pyredis/datastore/lock_datastore.py
@@ -1,7 +1,7 @@
 from threading import Lock
 
 
-class DataStore:
+class LockDataStore:
     def __init__(self):
         self._data = dict()
         self._lock = Lock()

--- a/pyredis/datastore/queue_datastore.py
+++ b/pyredis/datastore/queue_datastore.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from queue import Queue
 from threading import Thread
 
+
 @dataclass
 class Task:
     key: str = None

--- a/pyredis/datastore/queue_datastore.py
+++ b/pyredis/datastore/queue_datastore.py
@@ -1,0 +1,3 @@
+class QueueDataStore:
+    def __init__(self):
+        pass

--- a/pyredis/datastore/queue_datastore.py
+++ b/pyredis/datastore/queue_datastore.py
@@ -1,3 +1,71 @@
+# from queue import Queue
+# from threading import Thread
+
+# @dataclass
+# class Task:
+#     command: str
+#     key: str
+#     value: str
+#     response_queue: Queue
+#     response: int = 0
+
+
+# class TaskProcessor(Thread):
+#     def __init__(self):
+#         super().__init__(daemon=True)
+#         self._queue = Queue()
+
+#     def process(self, task):
+#         self._queue.put(task)
+
+#     def run(self):
+#         while True:
+#             task = self._queue.get()
+#             if task is not None:
+#                 task.response = task.val * 2
+#                 task.response_queue.put(task)
+
+
 class QueueDataStore:
     def __init__(self):
         pass
+
+
+# class QueueDataStore(Thread):
+#     def __init__(self):
+#         super().__init__(daemon=True)
+#         self._queue = Queue()
+#         self._data = dict()
+
+#     def process(self, task):
+#         self._queue.put(task)
+
+
+#     def run(self):
+#         while True:
+#             task = self._queue.get()
+#             if task is not None:
+#                 if task.command == "SET":
+#                     self._data[task.key] = task.value
+#                     task.response = "OK"
+#                 else:
+#                     task.response = self._data[task.key]
+#                 task.response_queue.put(task)
+
+
+# if __name__ == "__main__":
+#     processor = TaskProcessor()
+#     processor.start()
+
+#     # client / user of the processor
+#     result_queue = Queue()
+
+#     while True:
+#         try:
+#             v = input("Enter a value> ")
+#             processor.process(Task(int(v), result_queue))
+#             result = result_queue.get()
+#             print(result.response)
+#         except KeyboardInterrupt:
+#             print()
+#             break

--- a/pyredis/main.py
+++ b/pyredis/main.py
@@ -19,7 +19,7 @@ async def async_main(host, port, datastore):
         await instance_of_server.serve_forever()
 
 
-def main(host: str = None, port: int = None, threaded: bool = False, locked: bool = True):
+def main(host: str = None, port: int = None, threaded: bool = False, locked: bool = True, datastore=None):
     if host is None:
         host = DEFAULT_HOST
     if port is None:
@@ -28,11 +28,11 @@ def main(host: str = None, port: int = None, threaded: bool = False, locked: boo
         port = int(port)
 
     print("Initialize DataStore")
-    datastore = None
-    if locked:
-        datastore = LockDataStore()
-    else:
-        datastore = QueueDataStore()
+    if datastore is None:
+        if locked:
+            datastore = LockDataStore()
+        else:
+            datastore = QueueDataStore()
 
     print(f"Start PyRedis on host: {host}, port: {port}")
 

--- a/pyredis/main.py
+++ b/pyredis/main.py
@@ -17,7 +17,7 @@ async def async_main(host, port, datastore):
         await instance_of_server.serve_forever()
 
 
-def main(host: str = None, port: int = None, threaded: bool = False, locked: bool = True, datastore=None):
+def main(host: str = None, port: int = None, threaded: bool = False, locked: bool = False, datastore=None):
     if host is None:
         host = DEFAULT_HOST
     if port is None:

--- a/pyredis/main.py
+++ b/pyredis/main.py
@@ -1,8 +1,6 @@
 import asyncio
-from pyredis.server.threaded_server import threaded_server
-from pyredis.server.async_server import PyRedisAsyncServerProtocol
-from pyredis.datastore.lock_datastore import LockDataStore
-from pyredis.datastore.queue_datastore import QueueDataStore
+from pyredis.server import threaded_server, PyRedisAsyncServerProtocol
+from pyredis.datastore import LockDataStore, QueueDataStore
 
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 6380
@@ -27,11 +25,12 @@ def main(host: str = None, port: int = None, threaded: bool = False, locked: boo
     else:
         port = int(port)
 
-    print("Initialize DataStore")
     if datastore is None:
         if locked:
+            print("Initialize LockedDataStore")
             datastore = LockDataStore()
         else:
+            print("Initialize QueueDataStore")
             datastore = QueueDataStore()
 
     print(f"Start PyRedis on host: {host}, port: {port}")

--- a/pyredis/main.py
+++ b/pyredis/main.py
@@ -1,7 +1,8 @@
 import asyncio
 from pyredis.server.threaded_server import threaded_server
 from pyredis.server.async_server import PyRedisAsyncServerProtocol
-from pyredis.datastore import DataStore
+from pyredis.datastore.lock_datastore import LockDataStore
+from pyredis.datastore.queue_datastore import QueueDataStore
 
 DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 6380
@@ -18,7 +19,7 @@ async def async_main(host, port, datastore):
         await instance_of_server.serve_forever()
 
 
-def main(host: str = None, port: int = None, threaded: bool = False):
+def main(host: str = None, port: int = None, threaded: bool = False, locked: bool = True):
     if host is None:
         host = DEFAULT_HOST
     if port is None:
@@ -27,7 +28,12 @@ def main(host: str = None, port: int = None, threaded: bool = False):
         port = int(port)
 
     print("Initialize DataStore")
-    datastore = DataStore()
+    datastore = None
+    if locked:
+        datastore = LockDataStore()
+    else:
+        datastore = QueueDataStore()
+
     print(f"Start PyRedis on host: {host}, port: {port}")
 
     if threaded:

--- a/pyredis/server/__init__.py
+++ b/pyredis/server/__init__.py
@@ -1,0 +1,2 @@
+from .async_server import *
+from .threaded_server import *

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 import pyredis
 
+
 def setup_datastore():
     ds = QueueDataStore()
     ds.set("test_key", "test_value")
@@ -18,6 +19,7 @@ def async_server():
     threading.Thread(target=pyredis.main, kwargs={"threaded": False, "datastore": setup_datastore()}, daemon=True).start()
     time.sleep(0.1)  # 100ms
     yield
+
 
 # TODO: Blocked by  OSError: [Errno 48] Address already in use
 # when running with the async server

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -18,7 +18,8 @@ def async_server():
     time.sleep(0.1)  # 100ms
     yield
 
-
+# TODO: Blocked by  OSError: [Errno 48] Address already in use
+# when running with the async server
 # @pytest.fixture(scope="session")
 # def threaded_server():
 #     threading.Thread(target=pyredis.main, kwargs={"threaded": True, "datastore": setup_datastore()}, daemon=True).start()

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,14 +1,15 @@
 import time
 import threading
 
-from pyredis.datastore.lock_datastore import LockDataStore
+from pyredis.datastore import QueueDataStore
+
 import pytest
 
 import pyredis
 
 def setup_datastore():
-    ds = LockDataStore()
-    ds["test_key"] = "test_value"
+    ds = QueueDataStore()
+    ds.set("test_key", "test_value")
     return ds
 
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,6 +1,7 @@
 import time
 import threading
 
+from pyredis.datastore.lock_datastore import LockDataStore
 import pytest
 
 import pyredis
@@ -8,7 +9,9 @@ import pyredis
 
 @pytest.fixture(scope="session")
 def async_server():
-    threading.Thread(target=pyredis.main, kwargs={"threaded": False}, daemon=True).start()
+    ds = LockDataStore()
+    ds["test_key"] = "test_value"
+    threading.Thread(target=pyredis.main, kwargs={"threaded": False, "datastore": ds}, daemon=True).start()
     time.sleep(0.1)  # 100ms
     yield
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -6,18 +6,21 @@ import pytest
 
 import pyredis
 
+def setup_datastore():
+    ds = LockDataStore()
+    ds["test_key"] = "test_value"
+    return ds
+
 
 @pytest.fixture(scope="session")
 def async_server():
-    ds = LockDataStore()
-    ds["test_key"] = "test_value"
-    threading.Thread(target=pyredis.main, kwargs={"threaded": False, "datastore": ds}, daemon=True).start()
+    threading.Thread(target=pyredis.main, kwargs={"threaded": False, "datastore": setup_datastore()}, daemon=True).start()
     time.sleep(0.1)  # 100ms
     yield
 
 
-@pytest.fixture(scope="session")
-def threaded_server():
-    threading.Thread(target=pyredis.main, kwargs={"port": 6382, "threaded": True}, daemon=True).start()
-    time.sleep(0.1)  # 100ms
-    yield
+# @pytest.fixture(scope="session")
+# def threaded_server():
+#     threading.Thread(target=pyredis.main, kwargs={"threaded": True, "datastore": setup_datastore()}, daemon=True).start()
+#     time.sleep(0.1)  # 100ms
+#     yield

--- a/tests/integration_tests/test_echo.py
+++ b/tests/integration_tests/test_echo.py
@@ -1,7 +1,7 @@
 import subprocess
 
 
-def test_echo(async_server, threaded_server):
+def test_echo(async_server):
     res = subprocess.run(["redis-cli", "-p", "6380", "ECHO", "HELLO"], stdout=subprocess.PIPE)
     assert res.returncode == 0
     assert res.stdout.decode("utf-8").strip() == "HELLO"

--- a/tests/integration_tests/test_get.py
+++ b/tests/integration_tests/test_get.py
@@ -1,0 +1,18 @@
+import subprocess
+
+
+def test_get(async_server, threaded_server):
+    res = subprocess.run(["redis-cli", "-p", "6380", "GET", "test_key"], stdout=subprocess.PIPE)
+    assert res.returncode == 0
+    assert res.stdout.decode("utf-8").strip() == "test_value"
+
+
+def test_get_with_unknown_key(async_server, threaded_server):
+    res = subprocess.run(["redis-cli", "-p", "6380", "GET", "unknown_key"], stdout=subprocess.PIPE)
+    assert res.returncode == 0
+    assert res.stdout.decode("utf-8").strip() == ""
+
+
+def test_get_missing_argument(async_server, threaded_server):
+    res = subprocess.run(["redis-cli", "-p", "6380", "GET", "message", "key"], stdout=subprocess.PIPE)
+    assert res.stdout.decode("utf-8").strip() == "ERR wrong number of arguments for 'get' command"

--- a/tests/integration_tests/test_get.py
+++ b/tests/integration_tests/test_get.py
@@ -1,18 +1,18 @@
 import subprocess
 
 
-def test_get(async_server, threaded_server):
+def test_get(async_server):
     res = subprocess.run(["redis-cli", "-p", "6380", "GET", "test_key"], stdout=subprocess.PIPE)
     assert res.returncode == 0
     assert res.stdout.decode("utf-8").strip() == "test_value"
 
 
-def test_get_with_unknown_key(async_server, threaded_server):
+def test_get_with_unknown_key(async_server):
     res = subprocess.run(["redis-cli", "-p", "6380", "GET", "unknown_key"], stdout=subprocess.PIPE)
     assert res.returncode == 0
     assert res.stdout.decode("utf-8").strip() == ""
 
 
-def test_get_missing_argument(async_server, threaded_server):
+def test_get_missing_argument(async_server):
     res = subprocess.run(["redis-cli", "-p", "6380", "GET", "message", "key"], stdout=subprocess.PIPE)
     assert res.stdout.decode("utf-8").strip() == "ERR wrong number of arguments for 'get' command"

--- a/tests/integration_tests/test_ping.py
+++ b/tests/integration_tests/test_ping.py
@@ -1,13 +1,13 @@
 import subprocess
 
 
-def test_ping(async_server, threaded_server):
+def test_ping(async_server):
     res = subprocess.run(["redis-cli", "-p", "6380", "PING"], stdout=subprocess.PIPE)
     assert res.returncode == 0
     assert res.stdout.decode("utf-8").strip() == "PONG"
 
 
-def test_ping_with_param(async_server, threaded_server):
+def test_ping_with_param(async_server):
     res = subprocess.run(["redis-cli", "-p", "6380", "PING", "HELLO"], stdout=subprocess.PIPE)
     assert res.returncode == 0
     assert res.stdout.decode("utf-8").strip() == "HELLO"

--- a/tests/integration_tests/test_ping.py
+++ b/tests/integration_tests/test_ping.py
@@ -1,4 +1,3 @@
-# TODO: The following runs into a warning: OSError: [Errno 48] Address already in use
 import subprocess
 
 

--- a/tests/integration_tests/test_set.py
+++ b/tests/integration_tests/test_set.py
@@ -1,13 +1,13 @@
 import subprocess
 
 
-def test_set(async_server, threaded_server):
+def test_set(async_server):
     res = subprocess.run(["redis-cli", "-p", "6380", "SET", "message", "Hello World"], stdout=subprocess.PIPE)
     assert res.returncode == 0
     assert res.stdout.decode("utf-8").strip() == "OK"
 
 
-def test_set_missing_argument(async_server, threaded_server):
+def test_set_missing_argument(async_server):
     res = subprocess.run(["redis-cli", "-p", "6380", "SET", "message"], stdout=subprocess.PIPE)
     assert res.returncode == 0
     assert res.stdout.decode("utf-8").strip() == "ERR wrong number of arguments for 'set' command"

--- a/tests/integration_tests/test_set.py
+++ b/tests/integration_tests/test_set.py
@@ -1,0 +1,13 @@
+import subprocess
+
+
+def test_set(async_server, threaded_server):
+    res = subprocess.run(["redis-cli", "-p", "6380", "SET", "message", "Hello World"], stdout=subprocess.PIPE)
+    assert res.returncode == 0
+    assert res.stdout.decode("utf-8").strip() == "OK"
+
+
+def test_set_missing_argument(async_server, threaded_server):
+    res = subprocess.run(["redis-cli", "-p", "6380", "SET", "message"], stdout=subprocess.PIPE)
+    assert res.returncode == 0
+    assert res.stdout.decode("utf-8").strip() == "ERR wrong number of arguments for 'set' command"

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -6,8 +6,7 @@ REDIS Commands
 
 import pytest
 from pyredis.commands import parse_command
-from pyredis.datastore import DataStore
-
+from pyredis.datastore.lock_datastore import LockDataStore
 
 @pytest.mark.parametrize(
     "buffer, expected",
@@ -34,7 +33,7 @@ from pyredis.datastore import DataStore
     ],
 )
 def test_parse_command(buffer, expected):
-    datastore = DataStore()
+    datastore = LockDataStore()
     datastore["key1"] = "value1"
     got = parse_command(buffer, datastore)
     assert got == expected

--- a/tests/unit_tests/test_commands.py
+++ b/tests/unit_tests/test_commands.py
@@ -8,6 +8,7 @@ import pytest
 from pyredis.commands import parse_command
 from pyredis.datastore.lock_datastore import LockDataStore
 
+
 @pytest.mark.parametrize(
     "buffer, expected",
     [


### PR DESCRIPTION
## Changes
* Setup QueueDataStore which uses message passing to make changes into a dictionary instead of a Lock. 
* Change integration tests to use QueueDataStore instead of LockDataStore
* Only have integration tests with the async server (excludes the threading server)

## Known Issue (Fixed by https://github.com/clarissa-gunawan/pyredis/commit/f7d6e4454cd91a5f1a4d52dfccd3201cc2cb3fa5)
At its current state, the server cannot handle repeating called made by the redis-cli when it is async server. It works when it is a threading server.

### How to Reproduce
When running the server:
```
python -m pyredis
```

Run the redis client with repeats:
```
redis-cli -r 2 --help -p 6380 ECHO HI
```

Output:
The first message was process properly but the client exits with an error.
```
"HI"
Error: Connection reset by peer
```
